### PR TITLE
Add vertex validation callback for distance drawing modes

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -194,5 +194,13 @@ export default function(ctx, api) {
     return api;
   };
 
+  api.setValidateVertex = function(callback) {
+    if (callback !== null && typeof callback !== 'function') {
+      throw new Error('validateVertex must be a function or null');
+    }
+    ctx.options.validateVertex = callback;
+    return api;
+  };
+
   return api;
 }

--- a/src/modes/draw_line_string_distance.js
+++ b/src/modes/draw_line_string_distance.js
@@ -857,6 +857,13 @@ DrawLineStringDistance.clickOnMap = function (state, e) {
       })();
     }
 
+    if (this._ctx.options.validateVertex) {
+      const proposedCoords = [vertexCoord];
+      if (!this._ctx.options.validateVertex(proposedCoords)) {
+        return;
+      }
+    }
+
     state.vertices.push(vertexCoord);
     state.line.updateCoordinate(0, vertexCoord[0], vertexCoord[1]);
 
@@ -899,6 +906,13 @@ DrawLineStringDistance.clickOnMap = function (state, e) {
   // This ensures the vertex is placed exactly where the black dot indicator shows
   if (state.previewVertex) {
     const newVertex = state.previewVertex;
+
+    if (this._ctx.options.validateVertex) {
+      const proposedCoords = [...state.vertices, newVertex];
+      if (!this._ctx.options.validateVertex(proposedCoords)) {
+        return;
+      }
+    }
 
     state.vertices.push(newVertex);
     state.line.updateCoordinate(
@@ -955,6 +969,14 @@ DrawLineStringDistance.clickOnMap = function (state, e) {
   // If shift held, use raw mouse position (bypass snapping)
   if (shiftHeld) {
     newVertex = [e.lngLat.lng, e.lngLat.lat];
+
+    if (this._ctx.options.validateVertex) {
+      const proposedCoords = [...state.vertices, newVertex];
+      if (!this._ctx.options.validateVertex(proposedCoords)) {
+        return;
+      }
+    }
+
     state.vertices.push(newVertex);
     state.line.updateCoordinate(
       state.vertices.length - 1,
@@ -1439,6 +1461,13 @@ DrawLineStringDistance.clickOnMap = function (state, e) {
     const nearbyVertex = snapToNearbyVertex(newVertex, state.vertices, 0.5);
     if (nearbyVertex) {
       newVertex = nearbyVertex;
+    }
+  }
+
+  if (this._ctx.options.validateVertex) {
+    const proposedCoords = [...state.vertices, newVertex];
+    if (!this._ctx.options.validateVertex(proposedCoords)) {
+      return;
     }
   }
 

--- a/src/modes/draw_polygon_distance.js
+++ b/src/modes/draw_polygon_distance.js
@@ -1344,6 +1344,13 @@ DrawPolygonDistance.clickOnMap = function (state, e) {
         })();
     }
 
+    if (this._ctx.options.validateVertex) {
+      const proposedCoords = [vertexCoord];
+      if (!this._ctx.options.validateVertex(proposedCoords)) {
+        return;
+      }
+    }
+
     state.vertices.push(vertexCoord);
     state.polygon.updateCoordinate("0.0", vertexCoord[0], vertexCoord[1]);
 
@@ -1421,6 +1428,13 @@ DrawPolygonDistance.clickOnMap = function (state, e) {
       }
     }
 
+    if (this._ctx.options.validateVertex) {
+      const proposedCoords = [...state.vertices, newVertex];
+      if (!this._ctx.options.validateVertex(proposedCoords)) {
+        return;
+      }
+    }
+
     state.vertices.push(newVertex);
     state.polygon.updateCoordinate(
       `0.${state.vertices.length - 1}`,
@@ -1487,6 +1501,13 @@ DrawPolygonDistance.clickOnMap = function (state, e) {
       );
       if (dist < 10) {
         this.finishDrawing(state);
+        return;
+      }
+    }
+
+    if (this._ctx.options.validateVertex) {
+      const proposedCoords = [...state.vertices, newVertex];
+      if (!this._ctx.options.validateVertex(proposedCoords)) {
         return;
       }
     }
@@ -2041,6 +2062,13 @@ DrawPolygonDistance.clickOnMap = function (state, e) {
     const nearbyVertex = snapToNearbyVertex(newVertex, state.vertices, 0.5);
     if (nearbyVertex) {
       newVertex = nearbyVertex;
+    }
+  }
+
+  if (this._ctx.options.validateVertex) {
+    const proposedCoords = [...state.vertices, newVertex];
+    if (!this._ctx.options.validateVertex(proposedCoords)) {
+      return;
     }
   }
 

--- a/src/options.js
+++ b/src/options.js
@@ -55,6 +55,16 @@ const defaultOptions = {
    * ['2rem', 'calc(100% - 5rem)'] - lower-left area
    */
   angleDistanceInputPosition: ['50%', 'calc(100% - 3rem)'],
+
+  /**
+   * Callback function to validate vertices before they are added.
+   * Receives the proposed coordinates array and returns boolean.
+   * @type {function|null}
+   * @default null
+   * @param {Array<Array<number>>} proposedCoords - Array of [lng, lat] coordinates
+   * @returns {boolean} - true to allow vertex, false to reject
+   */
+  validateVertex: null,
 };
 
 const showControls = {


### PR DESCRIPTION
Adds setValidateVertex(callback) API to validate vertices before adding them in distance drawing modes.