### PR TITLE
Fix double-closed polygon rings in draw_polygon_distance mode

### DIFF
--- a/src/modes/draw_polygon_distance.js
+++ b/src/modes/draw_polygon_distance.js
@@ -3988,8 +3988,7 @@ DrawPolygonDistance.onKeyUp = function (state, e) {
       // Reset label back to "Length" when exiting offset phase
       setDistanceLabel(state, 'Length', 'L');
       // Reset polygon to line preview
-      const coords = [...state.vertices, state.vertices[0]];
-      state.polygon.setCoordinates([coords]);
+      state.polygon.setCoordinates([state.vertices]);
     } else if (state.vertices.length >= 3) {
       this.finishDrawing(state);
     } else {
@@ -4024,8 +4023,7 @@ DrawPolygonDistance.onKeyUp = function (state, e) {
       state.vertices.pop();
       // In rectangle mode, reset polygon to just the remaining vertices
       if (state.drawingSubMode === DRAWING_SUB_MODES.RECTANGLE) {
-        const coords = [...state.vertices, state.vertices[0]];
-        state.polygon.setCoordinates([coords]);
+        state.polygon.setCoordinates([state.vertices]);
         // Reset label back to "Length" when exiting RECTANGLE mode's width phase
         if (wasInRectangleWidthPhase) {
           setDistanceLabel(state, 'Length', 'L');
@@ -4394,8 +4392,7 @@ DrawPolygonDistance.finishDrawing = function (state) {
   }
 
   // Close the polygon
-  const closedCoords = [...state.vertices, state.vertices[0]];
-  state.polygon.setCoordinates([closedCoords]);
+  state.polygon.setCoordinates([state.vertices]);
 
   // Clean up indicators before finishing
   this.removeGuideCircle(state);
@@ -4455,10 +4452,7 @@ DrawPolygonDistance.onTrash = function (state) {
     state.vertices.pop();
 
     if (state.drawingSubMode === DRAWING_SUB_MODES.RECTANGLE) {
-      const coords = state.vertices.length > 1
-        ? [...state.vertices, state.vertices[0]]
-        : [state.vertices[0]];
-      state.polygon.setCoordinates([coords]);
+      state.polygon.setCoordinates([state.vertices]);
     } else {
       state.polygon.removeCoordinate(`0.${state.vertices.length}`);
       if (state.polygon.coordinates[0].length > state.vertices.length) {


### PR DESCRIPTION
Polygon.getCoordinates() already appends the closing coordinate, so manually appending vertices[0] before setCoordinates produced [A,B,C,A,A]. Removed the manual closure in all four call sites.