### PR TITLE
Fix setup.connect crash when called after onRemove

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -32,6 +32,7 @@ export default function (ctx) {
       return this;
     },
     connect() {
+      if (!ctx.map) return;
       ctx.map.off("load", setup.connect);
       clearInterval(mapLoadedInterval);
       setup.addLayers();


### PR DESCRIPTION
Add null guard for ctx.map in connect() to prevent crash when map is disposed before load event fires.

closes ParametricSolutions/gendes-api#4514